### PR TITLE
Add support for rofi's -e message mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Spawn [rofi](https://github.com/davatorium/rofi) windows, and parse the result a
 
 ## Simple example
 
-```
+```rust
 use rofi;
 use std::{fs, env};
 
@@ -22,7 +22,7 @@ match rofi::Rofi::new(&dir_entries).run() {
 ## Example of returning an index
 `rofi` can also be used to return an index of the selected item:
 
-```
+```rust
 use rofi;
 use std::{fs, env};
 
@@ -43,7 +43,7 @@ match rofi::Rofi::new(&dir_entries).run_index() {
 `rofi` can display pango format. Here is a simple example (you have to call
 the `self..pango` function).
 
-```
+```rust
 use rofi;
 use rofi::pango::{Pango, FontSize};
 use std::{fs, env};
@@ -57,5 +57,18 @@ match rofi::Rofi::new(&entries).pango().run() {
     Ok(element) => println!("Choice: {}", element),
     Err(rofi::Error::Interrupted) => println!("Interrupted"),
     Err(e) => println!("Error: {}", e)
+}
+```
+
+## Example of showing a message with no inputs
+`rofi` can display a message without any inputs. This is commonly used for error reporting.
+
+```rust
+use rofi;
+
+match rofi::Rofi::new_message("Something went wrong").run() {
+    Err(rofi::Error::Blank) => () // the expected case
+    Ok(_) => ()  // should not happen
+    Err(_) => () // Something went wrong
 }
 ```


### PR DESCRIPTION
This would be helpful for my use case, since I'm using Rofi as the primary UI for an interactive process with multiple steps, some of which could fail.
