### PR TITLE
Make types copy and clone where possible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ use thiserror::Error;
 /// multiple times without reconstruction and reallocation. You can choose to
 /// return a handle to the child process `RofiChild`, which allows you to kill
 /// the process.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Rofi<'a, T>
 where
     T: AsRef<str>,
@@ -348,7 +348,7 @@ impl<'a> Rofi<'a, String> {
 }
 
 /// Width of the rofi window to overwrite the default width from the rogi theme.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Width {
     /// No width specified, use the default one from the theme
     None,
@@ -383,7 +383,7 @@ impl Width {
 }
 
 /// Different modes, how rofi should return the results
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Format {
     /// Regular text, including markup
     #[allow(dead_code)]

--- a/src/pango.rs
+++ b/src/pango.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 /// Structure for writing Pango markup spans
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Pango<'a> {
     content: &'a str,
     options: HashMap<&'static str, &'a str>,
@@ -365,7 +365,7 @@ impl<'a> Pango<'a> {
 }
 
 /// Enumeration over all available font families
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum FontFamily {
     /// Normal font
     Normal,
@@ -378,7 +378,7 @@ pub enum FontFamily {
 }
 
 /// Enumeration over all avaliable font sizes
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum FontSize {
     /// Very tiny font size, corresponsds to xx-small
     VeryTiny,
@@ -401,7 +401,7 @@ pub enum FontSize {
 }
 
 /// Enumeration over all possible slant styles
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum SlantStyle {
     /// No slant
     Normal,
@@ -412,7 +412,7 @@ pub enum SlantStyle {
 }
 
 /// Enumeration over all possible weights
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Weight {
     /// Thin weight (=100)
     Thin,
@@ -437,7 +437,7 @@ pub enum Weight {
 }
 
 /// enumeration over all possible font stretch modes
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum FontStretch {
     /// UltraCondensed, letters are extremely close together
     UltraCondensed,
@@ -460,7 +460,7 @@ pub enum FontStretch {
 }
 
 /// enumeration over all possible underline modes
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Underline {
     /// No underline mode
     None,


### PR DESCRIPTION
The types not being copy and clone make them _really_ inconvenient to use in some situations. This PR makes all the types that _can_ be clone, be clone. Same with copy.

Tests passed without issues.